### PR TITLE
Expose TCP port on Docker Container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --no-cache --virtual \
 
 COPY . .
 
+EXPOSE 43508
 
 USER hypothesis
 


### PR DESCRIPTION
- Update to Dockerfile to expose a TCP port
- Required by Elastic Beanstalk

Part of the work towards:
- #1 